### PR TITLE
fixed ERR_CHANNELISFULL (mode +l)

### DIFF
--- a/include/numericReplies.hpp
+++ b/include/numericReplies.hpp
@@ -105,7 +105,7 @@
 // 405
 #define ERR_TOOMANYCHANNELS(server, nickname, channel) (std::string(":") + server +  " 405 " + nickname + " " + channel + " :You have joined too many channels\r\n") 
 // 353
-#define ERR_CHANNELISFULL(server, nickname, channel) (std::string(":") + server + " 353 " + nickname + " " + channel + " :Cannot join channel (+l)\r\n")
+#define ERR_CHANNELISFULL(server, nickname, channel) (std::string(":") + server + " 471 " + nickname + " " + channel + " :Cannot join channel (+l)\r\n")
 // 473
 #define ERR_INVITEONLYCHAN(server, nickname, channel) (std::string(":") + server + " 473 " + nickname + " " + channel + " :Cannot join channel (+i)\r\n")
 


### PR DESCRIPTION
- [x] Fixed ERR_CHANNELISFULL reply
- [x] also added : 
```
// check if channel is already full
if (it->second.getClientMap().size() >= MAXCLIENTS)
	return (ERR_CHANNELISFULL(client.getServerName(), client.getNickname(), it->second.getName()));
```
> before joining, server needs to check if mode +l has been set or if channel is already full (macro MAXCLIENT=100) 