### PR TITLE
Fixed `JOIN` error message (and other things)

### DIFF
--- a/include/Commands/Channels/Join.hpp
+++ b/include/Commands/Channels/Join.hpp
@@ -14,7 +14,7 @@ class Join : public ACommand
 		~Join();
 
     	void		handleRequest(Client &client, std::string arg);
-    	std::string	parseArgument(std::string& arg);
+    	std::string	parseArgument(Client &client, std::string& arg);
     	std::string action(Client &client);
 
 		std::string createErrorTooManyChannels(Client const &client, size_t idx);

--- a/include/numericReplies.hpp
+++ b/include/numericReplies.hpp
@@ -95,8 +95,10 @@
 #define JOIN_MSG(server, channel, nickname) (std::string(":") + nickname + "!" + nickname + "@" + server + " JOIN :" + channel + "\r\n")
 #define PART_MSG(server, channel, nickname, message) (std::string(":") + channel + "!" + server + " PART " + nickname +" :" + message+ "\r\n")
 
+// 448
+#define ERR_BADCHANAME(server, nickname, channel) (std::string(":") + server + " 448 " + nickname + " :Cannot join channel " + channel + ": Channel name must start with a hash mark (#)\r\n")
 // 476 
-#define ERR_BADCHANMASK(channel) (std::string(":") + channel + " 476 " + ":Bad Channel Mask\r\n")
+#define ERR_BADCHANMASK(server, channel) (std::string(":") + server + " 476 " + channel + " :Bad Channel Mask\r\n")
 // 475
 #define ERR_BADCHANNELKEY(server, nickname, channel) (std::string(":") + server +  " 475 " + nickname + " " + channel + " :Cannot join channel (+k)\r\n")
 // 405

--- a/src/Commands/Channels/Join.cpp
+++ b/src/Commands/Channels/Join.cpp
@@ -88,7 +88,7 @@ std::string		Join::action(Client &client)
 }
 
 
-std::string	Join::parseArgument(std::string& arg)
+std::string	Join::parseArgument(Client& client, std::string& arg)
 {
 	// split the channel list and the key list with a space
 	std::stringstream argStream(arg);
@@ -102,9 +102,11 @@ std::string	Join::parseArgument(std::string& arg)
 	std::stringstream channelStream(channelArg);
 	while (std::getline(channelStream, buffer, ','))
 	{
-		// check if channel channel name's length is at least 1
-		if (buffer.size() <= 1 || buffer.size() > CHANLEN)
-			return (ERR_BADCHANMASK(buffer));
+		// check if channel channel name's length is at least 2 (including #)
+		if (buffer.size() < 2 || buffer.size() > CHANLEN)
+			return (ERR_BADCHANMASK(client.getServerName(), buffer));
+		else if (buffer[0] != '#')
+			return (ERR_BADCHANAME(client.getServerName(), client.getNickname(), buffer));
 		_channelList.push_back(buffer);
 	}
 
@@ -136,7 +138,7 @@ void	Join::handleRequest(Client &client, std::string arg)
 	}
 	else
 	{
-		std::string parseResults = parseArgument(arg);
+		std::string parseResults = parseArgument(client, arg);
 		if (!parseResults.empty())
 			message = parseResults;
 		else

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -90,7 +90,7 @@ void	sendCustomNumericReply(const std::string& message, const int& code, const C
 	std::stringstream messageStream;
 	messageStream << ":" << client.getServerName() << " " << code << " " << client.getNickname() << " :" << message << "\r\n";
 	std::string returnMessage = messageStream.str();
-	send(client.getClientSocket(), returnMessage.c_str(), returnMessage.size(), 0);
+	sendNumericReplies(1, client.getClientSocket(), returnMessage.c_str());
 }
 
 // trim functions


### PR DESCRIPTION
# DONE
- [x] `JOIN`: when trying to join a channel that does not start with `#`, an error message is sent
- [x] `JOIN`: `BADCHANMASK` used to be send when the channel name length was < 1, now it's < 2 (since we assume the `#` sign is inluded) @jhparkkkk 
- [x] `ERR_BADCHANMASK` numeric reply updated
- [x] `ERR_BADCHANAME` numeric reply created (custom)
- [x] `sendCustomNumericReply()` now uses `sendNumericReplies()` instead of just `send()`

# Issues linked
- #72 