### PR TITLE
problem Fixed !

### DIFF
--- a/src/Commands/Mode.cpp
+++ b/src/Commands/Mode.cpp
@@ -176,7 +176,9 @@ void		Mode::applyChannelModes(Client& client, Channel& channel, std::string mode
 
 	for (size_t modesIndex = 1; modesIndex < modes.length(); ++modesIndex)
 	{
-		if (modes[modesIndex] == 'i' || modes[modesIndex] == 't')
+		if (successfullyChanged.find(modes[modesIndex], 0) != std::string::npos)
+			continue ;
+		else if (modes[modesIndex] == 'i' || modes[modesIndex] == 't')
 		{
 			if (changeMode == '+' && channel.modeIs(modes[modesIndex]) == false)
 			{


### PR DESCRIPTION
#89 
Fixed ! A flag will only be treated if it has not already been applied in the current run :
```C++
// Mode.cpp
if (successfullyChanged.find(modes[modesIndex], 0) != std::string::npos)
    continue ;
```